### PR TITLE
fix remaining uses of md5-c types and include paths

### DIFF
--- a/external/leach-uuid/uuid/sysdep.c
+++ b/external/leach-uuid/uuid/sysdep.c
@@ -18,6 +18,7 @@
  */
 
 #include <stdio.h>
+#include <string.h>
 #include "sysdep.h"
 
 /* system dependent call to get IEEE node ID.

--- a/external/leach-uuid/uuid/sysdep.c
+++ b/external/leach-uuid/uuid/sysdep.c
@@ -78,7 +78,7 @@ void get_system_time(uuid_time_t *uuid_time) {
 };
 
 void get_random_info(char seed[16]) {
-  MD5_CTX c;
+  md5_state_t c;
   typedef struct {
       MEMORYSTATUS m;
       SYSTEM_INFO s;
@@ -90,7 +90,7 @@ void get_random_info(char seed[16]) {
   } randomness;
   randomness r;
 
-  MD5Init(&c);
+  md5_init(&c);
   /* memory usage stats */
   GlobalMemoryStatus(&r.m);
   /* random system stats */
@@ -104,8 +104,8 @@ void get_random_info(char seed[16]) {
   r.l = MAX_COMPUTERNAME_LENGTH + 1;
 
   GetComputerName(r.hostname, &r.l );
-  MD5Update(&c, &r, sizeof(randomness));
-  MD5Final(seed, &c);
+  md5_append(&c, &r, sizeof(randomness));
+  md5_finish(&c, seed);
 };
 #else
 
@@ -124,7 +124,7 @@ void get_system_time(uuid_time_t *uuid_time)
 };
 
 void get_random_info(char seed[16]) {
-  MD5_CTX c;
+  md5_state_t c;
   typedef struct {
 #ifdef HAVE_SYS_SYSINFO_H
       struct sysinfo s;
@@ -141,7 +141,7 @@ void get_random_info(char seed[16]) {
   } randomness;
   randomness r;
 
-  MD5Init(&c);
+  md5_init(&c);
 
 #ifdef HAVE_SYS_SYSINFO_H
   sysinfo(&r.s);
@@ -156,8 +156,8 @@ void get_random_info(char seed[16]) {
 
   gettimeofday(&r.t, (struct timezone *)0);
   gethostname(r.hostname, 256);
-  MD5Update(&c, &r, sizeof(randomness));
-  MD5Final(seed, &c);
+  md5_append(&c, &r, sizeof(randomness));
+  md5_finish(&c, seed);
 };
 
 #endif

--- a/external/leach-uuid/uuid/sysdep.h
+++ b/external/leach-uuid/uuid/sysdep.h
@@ -35,7 +35,6 @@
 
 /* change to point to where MD5 .h's live */
 /* get MD5 sample implementation from RFC 1321 */
-#include "global.h"
 #include "md5.h"
 
 /* set the following to the number of 100ns ticks of the actual

--- a/modules/vapor/vpr/Util/uuid/Makefile.in
+++ b/modules/vapor/vpr/Util/uuid/Makefile.in
@@ -47,8 +47,8 @@ include @topdir@/make.defs.mk
 srcdir=			@srcdir@/../../../../../external/leach-uuid/uuid
 top_srcdir=		@top_srcdir@
 EXTRA_DEFS+=		@UUID_DEFS@
-EXTRA_DEPEND_FLAGS=	-I$(JUGGLERROOT_ABS)/external/md5-c
-EXTRA_INCLUDES+=	-I$(JUGGLERROOT_ABS)/external/md5-c
+EXTRA_DEPEND_FLAGS=	-I$(JUGGLERROOT_ABS)/external/libmd5-rfc
+EXTRA_INCLUDES+=	-I$(JUGGLERROOT_ABS)/external/libmd5-rfc
 INSTALL_FILES=
 SUBOBJDIR=		$(VPR_LIBRARY)
 


### PR DESCRIPTION
Hello,
IIRC these were causing build issues for me when I did not have a UUID library in system paths and so the one in external/leach-uuid was picked up.
