### PR TITLE
fixes for const correctness

### DIFF
--- a/modules/gadgeteer/drivers/ART/DTrack/DTrackStandalone.cpp
+++ b/modules/gadgeteer/drivers/ART/DTrack/DTrackStandalone.cpp
@@ -67,7 +67,7 @@ static char* string_get_i(char* str, int* i);
 static char* string_get_ui(char* str, unsigned int* ui);
 static char* string_get_d(char* str, double* d);
 static char* string_get_f(char* str, float* f);
-static char* string_get_block(char* str, char* fmt, int* idat, float* fdat);
+static char* string_get_block(char* str, const char* fmt, int* idat, float* fdat);
 
 
 // --------------------------------------------------------------------------
@@ -1136,7 +1136,7 @@ static char* string_get_f(char* str, float* f)
 // fdat (o): array for 'float' values (long enough due to fmt)
 // return value (o): pointer behind read value in str; NULL in case of error
 
-static char* string_get_block(char* str, char* fmt, int* idat, float* fdat)
+static char* string_get_block(char* str, const char* fmt, int* idat, float* fdat)
 {
 	char* strend;
 	int index_i, index_f;

--- a/modules/gadgeteer/drivers/Intersense/IS900/isdriver.cpp
+++ b/modules/gadgeteer/drivers/Intersense/IS900/isdriver.cpp
@@ -51,9 +51,21 @@ extern InterSenseTrackerType ISD_tracker[ISD_MAX_TRACKERS];
 ******************************************************************************/
 BOOL ISD_detectTrackerOld(InterSenseTrackerType *tracker/*, DWORD commPort*/)
 {
-    char   *systemName[MAX_HARDWARE_VERSIONS] =
-              {"IS-300 Series", "IS-600 Series", "IS-900 Series", "InterTrax", "Unknown"};
-    char   *message[4] = {"first", "second", "third", "fourth"};
+    const char   *systemName[MAX_HARDWARE_VERSIONS] =
+    {
+        "IS-300 Series",
+        "IS-600 Series",
+        "IS-900 Series",
+        "InterTrax",
+        "Unknown"
+    };
+    const char   *message[4] =
+    {
+        "first",
+        "second",
+        "third",
+        "fourth"
+    };
 
     WORD   numTracker;
 //    float  startTime;
@@ -182,9 +194,21 @@ BOOL ISD_detectTrackerOld(InterSenseTrackerType *tracker/*, DWORD commPort*/)
 ////////////////////////////////////////////////////////////////////////////////
 BOOL ISD_detectTracker(InterSenseTrackerType *tracker, std::string com_port, int baud_rate)
 {
-    char   *systemName[MAX_HARDWARE_VERSIONS] =
-              {"IS-300 Series", "IS-600 Series", "IS-900 Series", "InterTrax", "Unknown"};
-    char   *message[4] = {"first", "second", "third", "fourth"};
+    const char   *systemName[MAX_HARDWARE_VERSIONS] =
+    {
+        "IS-300 Series",
+        "IS-600 Series",
+        "IS-900 Series",
+        "InterTrax",
+        "Unknown"
+    };
+    const char   *message[4] =
+    {
+        "first",
+        "second",
+        "third",
+        "fourth"
+    };
 
     WORD   numTracker;
 //    float  startTime;
@@ -464,7 +488,7 @@ BOOL ISD_detectTracker(InterSenseTrackerType *tracker, std::string com_port, int
 *                   set correctly.
 *
 ******************************************************************************/
-BOOL ISD_sendCommand(InterSenseTrackerType *tracker, char *command)
+BOOL ISD_sendCommand(InterSenseTrackerType *tracker, const char *command)
 {
     if(wsockIsClient(tracker)) return FAIL;
 
@@ -1374,7 +1398,7 @@ BOOL ISD_allowUserCommand ( char *cmd )
 
 
 /***************************************************************************/
-void ISD_printf ( InterSenseTrackerType *tracker, char *fs,... )
+void ISD_printf ( InterSenseTrackerType *tracker, const char *fs,... )
 {
    boost::ignore_unused_variable_warning(tracker);
 

--- a/modules/gadgeteer/drivers/Intersense/IS900/isdriver.h
+++ b/modules/gadgeteer/drivers/Intersense/IS900/isdriver.h
@@ -241,13 +241,13 @@ void ISD_getTrackerData( InterSenseTrackerType * );
  
 BOOL processInterTraxDataRecord(InterSenseTrackerType *tracker, char *cmdbuf, int numChars);
 
-BOOL ISD_sendCommand( InterSenseTrackerType * , char * );
+BOOL ISD_sendCommand( InterSenseTrackerType * , const char * );
 BOOL ISD_setOutputRecordList( InterSenseTrackerType *, ISD_STATION_INFO_TYPE *, WORD );
 BOOL ISD_configureTracker( InterSenseTrackerType *tracker, BOOL verbose );
 BOOL ISD_allowUserCommand( char * );
 BOOL ISD_applyConfiguration( InterSenseTrackerType *tracker, BOOL verbose );
 void ISD_displayTransferRate( float bps, float sps );
-void ISD_printf( InterSenseTrackerType *tracker, char *fs,... );
+void ISD_printf( InterSenseTrackerType *tracker, const char *fs,... );
 
 int  wsockIsClient( InterSenseTrackerType *tracker );
 int  wsockReceiveData( InterSenseTrackerType *tracker );

--- a/modules/gadgeteer/drivers/Intersense/IS900/itcom.cpp
+++ b/modules/gadgeteer/drivers/Intersense/IS900/itcom.cpp
@@ -57,7 +57,7 @@ static DWORD charToNum(BYTE c);
 /***************************************************************************/
 /* all commands must be sent with this function */
 
-int itSendCommand(InterSenseTrackerType *tracker, char *fs,...)
+int itSendCommand(InterSenseTrackerType *tracker, const char *fs,...)
 {
     char sbuf[256];
     va_list argptr;

--- a/modules/gadgeteer/drivers/Intersense/IS900/itcom.h
+++ b/modules/gadgeteer/drivers/Intersense/IS900/itcom.h
@@ -97,7 +97,7 @@ typedef struct
 void serviceSerialPort( InterSenseTrackerType *tracker );
 void ISD_INTERTRAX_serviceSerialPort(InterSenseTrackerType *tracker);
 void requestTrackerUpdate( InterSenseTrackerType *tracker );
-int  itSendCommand( InterSenseTrackerType *tracker, char *fs,... );
+int  itSendCommand( InterSenseTrackerType *tracker, const char *fs,... );
 char stationToChar( DWORD stationNum );
 
 BOOL itComUpdateStationStat( InterSenseTrackerType *tracker, DWORD sensorNum );

--- a/modules/gadgeteer/drivers/Intersense/IS900/serial.cpp
+++ b/modules/gadgeteer/drivers/Intersense/IS900/serial.cpp
@@ -555,7 +555,7 @@ BOOL rs232SetRTSState(COMM_PORT *port, DWORD value)
 /****************************************************************************/
 int rs232InitCommunicationsOld(COMM_PORT *port, DWORD comPort, DWORD baudRate)
 {
-    char *portNames[4] =
+    const char *portNames[4] =
 #if defined VPR_OS_IRIX
     {"/dev/ttyd11", "/dev/ttyd11", "/dev/ttyd11", "/dev/ttyd11"};
 #elif defined VPR_OS_Linux

--- a/modules/gadgeteer/drivers/USDigital/SerialEncoder/SEIBus.h
+++ b/modules/gadgeteer/drivers/USDigital/SerialEncoder/SEIBus.h
@@ -255,7 +255,7 @@ public:
    }
 
 private:
-   void reportError(char *error)
+   void reportError(const char *error)
    {
       if ( reportErrors )
       {


### PR DESCRIPTION
Converts char* to const char* arguments for format strings. This silences warnings about implicit conversions when passing literal strings to these functions.