### PR TITLE
convert remaining uses of boost::signals to boost::signals2

### DIFF
--- a/modules/gadgeteer/gadget/Event/MultiEventGenerator.h
+++ b/modules/gadgeteer/gadget/Event/MultiEventGenerator.h
@@ -43,7 +43,7 @@
 #include <boost/mpl/for_each.hpp>
 #include <boost/bind.hpp>
 #include <boost/bind/apply.hpp>
-#include <boost/signals/connection.hpp>
+#include <boost/signals2/connection.hpp>
 
 #include <gadget/Type/ProxyTraits.h>
 #include <gadget/Event/EventGenerator.h>
@@ -473,8 +473,8 @@ private:
 
    SampleHandler mSampleHandler;
    proxy_ptr_type mProxy;
-   boost::signals::connection mDevConn;
-   boost::signals::connection mRefreshConn;
+   boost::signals2::connection mDevConn;
+   boost::signals2::connection mRefreshConn;
 };
 
 }

--- a/modules/gadgeteer/gadget/Type/Analog.h
+++ b/modules/gadgeteer/gadget/Type/Analog.h
@@ -31,7 +31,7 @@
 
 #include <vector>
 #include <boost/noncopyable.hpp>
-#include <boost/signal.hpp>
+#include <boost/signals2/signal.hpp>
 
 #include <vpr/Util/SignalProxy.h>
 #include <vpr/IO/SerializableObject.h>
@@ -78,7 +78,8 @@ class GADGET_API Analog
 {
 public:
    typedef SampleBuffer<AnalogData> SampleBuffer_t;
-   typedef boost::signal<void (const std::vector<AnalogData>&)> add_signal_t;
+   typedef boost::signals2::signal<void (const std::vector<AnalogData>&)>
+      add_signal_t;
 
 protected:
    /**

--- a/modules/gadgeteer/gadget/Type/Command.h
+++ b/modules/gadgeteer/gadget/Type/Command.h
@@ -31,7 +31,7 @@
 
 #include <vector>
 #include <boost/noncopyable.hpp>
-#include <boost/signal.hpp>
+#include <boost/signals2/signal.hpp>
 
 #include <vpr/Util/SignalProxy.h>
 #include <vpr/IO/SerializableObject.h>
@@ -71,7 +71,8 @@ class GADGET_API Command
 {
 public:
    typedef SampleBuffer<CommandData> SampleBuffer_t;
-   typedef boost::signal<void (const std::vector<CommandData>&)> add_signal_t;
+   typedef boost::signals2::signal<void (const std::vector<CommandData>&)>
+      add_signal_t;
 
 protected:
    /* Constructor/Destructors */

--- a/modules/gadgeteer/gadget/Type/Digital.h
+++ b/modules/gadgeteer/gadget/Type/Digital.h
@@ -31,7 +31,7 @@
 
 #include <vector>
 #include <boost/noncopyable.hpp>
-#include <boost/signal.hpp>
+#include <boost/signals2/signal.hpp>
 
 #include <vpr/Util/SignalProxy.h>
 #include <vpr/IO/SerializableObject.h>
@@ -69,7 +69,8 @@ class GADGET_API Digital
 {
 public:
    typedef SampleBuffer<DigitalData> SampleBuffer_t;
-   typedef boost::signal<void (const std::vector<DigitalData>&)> add_signal_t;
+   typedef boost::signals2::signal<void (const std::vector<DigitalData>&)>
+      add_signal_t;
 
    /** @name Compatibility */
    //@{

--- a/modules/gadgeteer/gadget/Type/Hat.h
+++ b/modules/gadgeteer/gadget/Type/Hat.h
@@ -31,7 +31,7 @@
 
 #include <vector>
 #include <boost/noncopyable.hpp>
-#include <boost/signal.hpp>
+#include <boost/signals2/signal.hpp>
 
 #include <vpr/Util/SignalProxy.h>
 #include <vpr/IO/SerializableObject.h>
@@ -69,7 +69,8 @@ class GADGET_API Hat
 {
 public:
    typedef SampleBuffer<HatData> SampleBuffer_t;
-   typedef boost::signal<void (const std::vector<HatData>&)> add_signal_t;
+   typedef boost::signals2::signal<void (const std::vector<HatData>&)>
+      add_signal_t;
 
    /** @name Compatibility */
    //@{

--- a/modules/gadgeteer/gadget/Type/KeyboardMouse.h
+++ b/modules/gadgeteer/gadget/Type/KeyboardMouse.h
@@ -32,7 +32,7 @@
 #include <string>
 #include <vector>
 #include <boost/noncopyable.hpp>
-#include <boost/signal.hpp>
+#include <boost/signals2/signal.hpp>
 
 #include <vpr/IO/SerializableObject.h>
 #include <vpr/Sync/Mutex.h>
@@ -67,7 +67,8 @@ class GADGET_API KeyboardMouse
 {
 public:
    typedef KeyboardMouseData::data_type EventQueue;
-   typedef boost::signal<void (const EventPtr&)> add_signal_t;
+   typedef boost::signals2::signal<void (const EventPtr&)>
+      add_signal_t;
 
    static const vpr::Uint16 type_id;
 

--- a/modules/gadgeteer/gadget/Type/Position.h
+++ b/modules/gadgeteer/gadget/Type/Position.h
@@ -38,7 +38,7 @@
 #include <typeinfo>
 #include <vector>
 #include <boost/noncopyable.hpp>
-#include <boost/signal.hpp>
+#include <boost/signals2/signal.hpp>
 
 #include <gmtl/Matrix.h>
 
@@ -79,7 +79,8 @@ class GADGET_API Position
 {
 public:
    typedef SampleBuffer<PositionData> SampleBuffer_t;
-   typedef boost::signal<void (const std::vector<PositionData>&)> add_signal_t;
+   typedef boost::signals2::signal<void (const std::vector<PositionData>&)>
+      add_signal_t;
 
 protected:
    /** Constructor */

--- a/modules/gadgeteer/gadget/Type/Proxy.h
+++ b/modules/gadgeteer/gadget/Type/Proxy.h
@@ -31,7 +31,7 @@
 
 #include <typeinfo>
 #include <boost/optional.hpp>
-#include <boost/signal.hpp>
+#include <boost/signals2/signal.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/mpl/eval_if.hpp>
 #include <boost/mpl/identity.hpp>
@@ -185,7 +185,8 @@ namespace gadget
       typedef typename device_traits_type::device_ptr_type device_ptr_type;
       typedef typename device_traits_type::data_type       device_data_type;
       typedef typename device_data_type::data_type         raw_data_type;
-      typedef boost::signal<void (device_ptr_type)>        refresh_signal_type;
+      typedef boost::signals2::signal<void (device_ptr_type)>
+         refresh_signal_type;
 
       /**
        * Determines the return type for getData(). When raw_data_type is a

--- a/modules/gadgeteer/gadget/Type/Rumble.h
+++ b/modules/gadgeteer/gadget/Type/Rumble.h
@@ -32,7 +32,6 @@
 #include <vector>
 #include <boost/concept_check.hpp>   /* for ignore_unused_variable_warning */
 #include <boost/noncopyable.hpp>
-#include <boost/signal.hpp>
 
 #include <cppdom/cppdom.h>
 

--- a/modules/gadgeteer/gadget/Type/String.h
+++ b/modules/gadgeteer/gadget/Type/String.h
@@ -31,7 +31,7 @@
 
 #include <vector>
 #include <boost/noncopyable.hpp>
-#include <boost/signal.hpp>
+#include <boost/signals2/signal.hpp>
 
 #include <vpr/Util/SignalProxy.h>
 #include <vpr/IO/SerializableObject.h>
@@ -77,7 +77,8 @@ class GADGET_API String
 {
 public:
    typedef SampleBuffer<StringData> SampleBuffer_t;
-   typedef boost::signal<void (const std::vector<StringData>&)> add_signal_t;
+   typedef boost::signals2::signal<void (const std::vector<StringData>&)>
+      add_signal_t;
 
 public:
    /* Constructor/Destructors */

--- a/modules/vapor/vpr/Util/SignalProxy.h
+++ b/modules/vapor/vpr/Util/SignalProxy.h
@@ -19,7 +19,7 @@
 #ifndef _VPR_SIGNAL_PROXY_H_
 #define _VPR_SIGNAL_PROXY_H_
 
-#include <boost/signals/connection.hpp>
+#include <boost/signals2/connection.hpp>
 
 
 namespace vpr
@@ -62,7 +62,7 @@ public:
       /* Do nothing. */ ;
    }
 
-   boost::signals::connection connect(typename signal_t::slot_type slot)
+   boost::signals2::connection connect(typename signal_t::slot_type slot)
    {
       return mSignal.connect(slot);
    }
@@ -76,7 +76,7 @@ public:
     *
     * @since 0.26.1
     */
-   boost::signals::connection
+   boost::signals2::connection
    connect(const typename signal_t::group_type& group,
            typename signal_t::slot_type slot)
    {


### PR DESCRIPTION
There were some leftover uses of the (deprecated) boost::signals in the tree, this hopefully caught them all and converted them to boost::signals2.