### PR TITLE
fix PropertyDefinition '==' comparision

### DIFF
--- a/modules/jackal/config/jccl/Config/PropertyDefinition.cpp
+++ b/modules/jackal/config/jccl/Config/PropertyDefinition.cpp
@@ -166,7 +166,7 @@ bool PropertyDefinition::operator== (const PropertyDefinition& pd) const
    mNode->save(self_string);
    pd.mNode->save(d_string);
 
-   return (self_string == d_string);
+   return (self_string.str() == d_string.str());
 }
 
 bool PropertyDefinition::operator!= (const PropertyDefinition& pd) const


### PR DESCRIPTION
std::ostringstream are not '==' comparable, compare the contained
strings instead.