### PR TITLE
Configure input devices on slave nodes

### DIFF
--- a/modules/gadgeteer/gadget/Type/InputDevice.h
+++ b/modules/gadgeteer/gadget/Type/InputDevice.h
@@ -119,6 +119,15 @@ public:
    static const type_id_type type_id =
       gadget::type::compose_id<type_list>::type::value;
 
+   virtual bool config(jccl::ConfigElementPtr e)
+   {
+      Input::config(e);
+      Caller<ConfigInvoker> caller(this, e);
+      boost::mpl::for_each<type_list, wrap<boost::mpl::_1> >(caller);
+
+      return true;
+   }
+
    /** @name vpr::SerializableObject Overrides */
    //@{
    virtual void writeObject(vpr::ObjectWriter* writer)
@@ -162,6 +171,17 @@ private:
          typedef wrap<U> type;
       };
 #endif
+   };
+
+   struct ConfigInvoker
+   {
+      typedef jccl::ConfigElementPtr arg_type;
+
+      template <typename BaseType>
+      static void invoke(BaseType* obj, jccl::ConfigElementPtr e)
+      {
+         obj->BaseType::config(e);
+      }
    };
 
    struct WriteInvoker

--- a/modules/gadgeteer/plugins/RIMPlugin/RIMPlugin.cpp
+++ b/modules/gadgeteer/plugins/RIMPlugin/RIMPlugin.cpp
@@ -255,6 +255,23 @@ void RIMPlugin::handlePacket(cluster::PacketPtr packet, gadget::NodePtr node)
                input_dev = getVirtualDevice(device_name);
                vprASSERT(NULL != input_dev.get() && "Can't have a NULL device.");
                gadget::InputManager::instance()->addRemoteDevice(input_dev, device_name);
+
+               // obtain config element for device
+               jccl::ConfigElementPtr dev_cfg =
+                  jccl::ConfigManager::instance()->getElementNamed(device_name);
+
+               if ( NULL != dev_cfg.get() )
+               {
+                  input_dev->config(dev_cfg);
+               }
+               else
+               {
+                  vprDEBUG(gadgetDBG_RIM,vprDBG_CONFIG_LVL)
+                     << clrOutBOLD(clrRED, "ERROR:")
+                     << "[RIMPlugin::handlePacket] No config element found for device '"
+                     << device_name << "'!\n"
+                     << vprDEBUG_FLUSH;
+               }
             }
             break;
          }


### PR DESCRIPTION
The virtual devices on slave nodes are never configured and as a
consequence the base input types (Analog, Digital, ...) never have any
configuration applied.
This makes a noticeable difference for Analog when the device does not
produce values that are already in the normalized [0,1] range. A device
producing raw values in [-1,1] (and appropriately configured min/max
values) does not behave correctly on slave nodes, because the slave is
using the default min/max values instead of those specified in the config.

The solution is to forward config elements from InputDevice to all
bases and in the RIMPlugin pass the ConfigElement for a device to the
virtual device when it is first created.