### PR TITLE
Feature trackd windows port

### DIFF
--- a/modules/gadgeteer/drivers/Open/Trackd/TrackdControllerStandalone.cpp
+++ b/modules/gadgeteer/drivers/Open/Trackd/TrackdControllerStandalone.cpp
@@ -5,42 +5,43 @@
 /** Gets the num input values. */
 int TrackdControllerStandalone::numButtons()
 {
-   assert(mMem != NULL);
-   return trackd_num_buttons(mMem);
+   assert(mCon != NULL);
+   return trackd_controller_num_buttons(mCon);
 }
 int TrackdControllerStandalone::numValuators()
 {
-   assert(mMem != NULL);
-   return trackd_num_valuators(mMem);
+   assert(mCon != NULL);
+   return trackd_controller_num_valuators(mCon);
 }
 
 /** Returns the value of the button. */
 int TrackdControllerStandalone::getButton(int btnNum)
 {
-   assert(mMem != NULL);
-   return trackd_button(mMem, btnNum);
+   assert(mCon != NULL);
+   return trackd_controller_button(mCon, btnNum);
 }
-
 
 float TrackdControllerStandalone::getValuator(int valNum)
 {
-   assert(mMem != NULL);
-   return trackd_valuator(mMem, valNum);
+   assert(mCon != NULL);
+   return trackd_controller_valuator(mCon, valNum);
 }
 
 /**
  * Attaches to the memory segment with key (mShmKey).
- * @post mMem = address of the shared memory area.
+ * @post mCon = address of ControllerConnection object.
  */
 void TrackdControllerStandalone::attachToMem()
 {
    assert(mShmKey != 0 && "Key was not set correctly");
-   mMem = trackd_attach_tracker_mem(mShmKey);
+   assert(mCon    == NULL && "Already attached");
+   mCon = trackd_controller_attach(mShmKey);
 }
 
-/** Releases the memory segment of mMem. */
+/** Releases the ControllerConnection object. */
 void TrackdControllerStandalone::releaseMem()
 {
-   assert(mMem != NULL && "Trying to release trackd memory that was NULL");
-   trackd_release_tracker_mem(mMem);
+   assert(mCon != NULL && "Trying to release trackd memory that was NULL");
+   trackd_controller_release(mCon);
+   mCon = NULL;
 }

--- a/modules/gadgeteer/drivers/Open/Trackd/TrackdControllerStandalone.h
+++ b/modules/gadgeteer/drivers/Open/Trackd/TrackdControllerStandalone.h
@@ -8,10 +8,9 @@ class TrackdControllerStandalone
 {
 public:
    TrackdControllerStandalone(int shmKey)
+      : mShmKey(shmKey)
+      , mCon   (NULL)
    {
-      mShmKey = shmKey;
-      //mMem = NULL;
-
       // Attach immediately
       attachToMem();
    }
@@ -41,8 +40,8 @@ protected:
    void releaseMem();
 
 private:
-   int   mShmKey;       /**< The key to the shared memory area. */
-   void* mMem;          /**< The memory area. */
+   int                   mShmKey;       /**< The key to the shared memory area. */
+   ControllerConnection* mCon;          /**< The connection info. */
 };
 
 

--- a/modules/gadgeteer/drivers/Open/Trackd/TrackdSensorStandalone.cpp
+++ b/modules/gadgeteer/drivers/Open/Trackd/TrackdSensorStandalone.cpp
@@ -10,19 +10,18 @@
 
 int TrackdSensorStandalone::numSensors()
 {
-   assert(mMem != NULL);
-   assert(mShmKey != 0);
-   return trackd_num_sensors(mMem);
+   assert(mTrack  != NULL);
+   return trackd_tracker_num_sensors(mTrack);
 }
 
 // Return the position of the given sensor
 gmtl::Matrix44f TrackdSensorStandalone::getSensorPos(int sensorNum)
 {
-   assert(mMem != NULL && "We don't have a valid trackd memory area");
+   assert(mTrack != NULL && "We don't have a valid trackd memory area");
    assert(sensorNum < numSensors() && "Out of bounds request for a sensor");
 
    CAVE_SENSOR_ST* sensor_val;
-   sensor_val = trackd_sensor(mMem, sensorNum);
+   sensor_val = trackd_tracker_sensor(mTrack, sensorNum);
 
    // For Anthony Steed
    gmtl::Matrix44f ret_val;
@@ -48,13 +47,14 @@ gmtl::Matrix44f TrackdSensorStandalone::getSensorPos(int sensorNum)
 void TrackdSensorStandalone::attachToMem()
 {
    assert(mShmKey != 0 && "Key was not set correctly");
-   mMem = trackd_attach_tracker_mem(mShmKey);
+   assert(mTrack  == NULL && "Already attached");
+   mTrack = trackd_tracker_attach(mShmKey);
 }
 
 /** Release the memory segment of mMem. */
 void TrackdSensorStandalone::releaseMem()
 {
-   assert(mMem != NULL && "Trying to release trackd memory that was NULL");
-   trackd_release_tracker_mem(mMem);
+   assert(mTrack != NULL && "Trying to release trackd memory that was NULL");
+   trackd_tracker_release(mTrack);
+   mTrack = NULL;
 }
-

--- a/modules/gadgeteer/drivers/Open/Trackd/TrackdSensorStandalone.h
+++ b/modules/gadgeteer/drivers/Open/Trackd/TrackdSensorStandalone.h
@@ -8,10 +8,9 @@ class TrackdSensorStandalone
 {
 public:
    TrackdSensorStandalone(int shmKey)
+      : mShmKey(shmKey)
+      , mTrack (NULL)
    {
-      mShmKey = shmKey;
-      mMem = NULL;
-
       // Attach immediately
       attachToMem();
    }
@@ -38,8 +37,8 @@ protected:
    void releaseMem();
 
 private:
-   int   mShmKey;       /**< The key to the shared memory area. */
-   void* mMem;          /**< The memory area. */
+   int                mShmKey;       /**< The key to the shared memory area. */
+   TrackerConnection* mTrack;        /**< The tracker info. */
 };
 
 #endif

--- a/modules/gadgeteer/drivers/Open/Trackd/trackdmem.cpp
+++ b/modules/gadgeteer/drivers/Open/Trackd/trackdmem.cpp
@@ -21,7 +21,7 @@ struct TrackerConnection
    HANDLE                     file_mapping;
    CAVE_TRACKDTRACKER_HEADER* tracker;
 #else
-   int
+   int                        shmid;
    CAVE_TRACKDTRACKER_HEADER* tracker;
 #endif
 };
@@ -175,7 +175,7 @@ trackd_controller_attach(int shmKey)
 
    c->controller =
       reinterpret_cast<CAVE_TRACKDCONTROLLER_HEADER*>(
-         shmat(controller_shmid, (void *) 0, 0));
+         shmat(c->shmid, (void *) 0, 0));
 
    if(c->controller == (CAVE_TRACKDCONTROLLER_HEADER *) -1)
    {

--- a/modules/gadgeteer/drivers/Open/Trackd/trackdmem.cpp
+++ b/modules/gadgeteer/drivers/Open/Trackd/trackdmem.cpp
@@ -5,142 +5,246 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>
-#include <sys/ipc.h>
-#include <sys/shm.h>
 #include <drivers/Open/Trackd/trackdmem.h>
 
+#if !defined(VPR_OS_Windows)
+#include <sys/ipc.h>
+#include <sys/shm.h>
+#endif
 
-/*************************************************************************
- void * trackd_attach_tracker_mem(int)
-   Attaches to shared memory for the sensors.  The argument is the key
-  # for the shared memory segment.  The returned value points to the chunk.
-**************************************************************************/
-void * trackd_attach_tracker_mem(int shmKey)
+// ===========================================================================
+// trackd tracker API
+
+struct TrackerConnection
+{
+#if defined(VPR_OS_Windows)
+   HANDLE                     file_mapping;
+   CAVE_TRACKDTRACKER_HEADER* tracker;
+#else
+   int
+   CAVE_TRACKDTRACKER_HEADER* tracker;
+#endif
+};
+
+TrackerConnection*
+trackd_tracker_attach(int shmKey)
+{
+   TrackerConnection* t = new TrackerConnection();
+
+#if defined(VPR_OS_Windows)
+   char shmfile[256];
+   sprintf(shmfile, "%d", shmKey);
+   t->file_mapping = OpenFileMapping(FILE_MAP_READ, FALSE, shmfile);
+
+   if(!t->file_mapping)
    {
-   CAVE_TRACKDTRACKER_HEADER *tracker;
-   int tracker_shmid = shmget(shmKey,sizeof(CAVE_TRACKDTRACKER_HEADER),0);
-   if (tracker_shmid < 0)
-      {
+      fprintf(stderr, "ERROR: cannot get tracker shared memory\n");
+      perror("OpenFileMapping");
+      return NULL;
+   }
+
+   t->tracker =
+      reinterpret_cast<CAVE_TRACKDTRACKER_HEADER*>(
+         MapViewOfFile(t->file_mapping, FILE_MAP_READ, 0, 0, 0));
+
+   if(!t->tracker)
+   {
+      fprintf(stderr, "ERROR: cannot attach tracker shared memory\n");
+      perror("MapViewOfFile");
+      return NULL;
+   }
+#else
+   t->shmid = shmget(shmKey, sizeof(CAVE_TRACKDTRACKER_HEADER), 0);
+
+   if(t->shmid < 0)
+   {
       fprintf(stderr,"ERROR: can't get tracker shared memory\n");
       perror("shmget");
       return NULL;
-      }
-   tracker = (CAVE_TRACKDTRACKER_HEADER *) shmat(tracker_shmid,
-                     (void *) 0, 0);
-   if (tracker == (CAVE_TRACKDTRACKER_HEADER *) -1)
-      {
+   }
+
+   t->tracker =
+      reinterpret_cast<CAVE_TRACKDTRACKER_HEADER*>(
+         shmat(t->shmid, (void *) 0, 0));
+
+   if(t->tracker == reinterpret_cast<CAVE_TRACKDTRACKER_HEADER*>(-1))
+   {
       fprintf(stderr,"ERROR: can't attach tracker shared memory\n");
       perror("shmat");
       return NULL;
-      }
-   return tracker;
    }
-
-
-void trackd_release_tracker_mem(void *mem)
-   {
-#ifdef __sun__
-#   if defined(_XOPEN_SOURCE) && (_XOPEN_VERSION - 0 >= 4)
-   shmdt(mem);
-#   else
-   shmdt((char*) mem);
-#   endif
-#else
-   shmdt(mem);
 #endif
+
+   return t;
+}
+
+void
+trackd_tracker_release(TrackerConnection* t)
+{
+#if defined(VPR_OS_Windows)
+   if(t && t->tracker)
+   {
+      UnmapViewOfFile(t->tracker);
+      CloseHandle(t->file_mapping);
+   }
+#else
+   if(t && t->tracker)
+   {
+#  ifdef __sun__
+#     if defined(_XOPEN_SOURCE) && (_XOPEN_VERSION - 0 >= 4)
+      shmdt(t->tracker);
+#     else
+      shmdt((char*) t->tracker);
+#     endif
+#  else
+      shmdt(t->tracker);
+#  endif
+   }
+#endif
+
+   delete t;
+}
+
+int
+trackd_tracker_num_sensors(TrackerConnection* t)
+{
+   return t->tracker->numSensors;
+}
+
+CAVE_SENSOR_ST*
+trackd_tracker_sensor(TrackerConnection* t, int sensorNum)
+{
+   unsigned char* pointer =
+      reinterpret_cast<unsigned char*>(t->tracker);
+
+   pointer += t->tracker->sensorOffset + sensorNum * t->tracker->sensorSize;
+
+   return reinterpret_cast<CAVE_SENSOR_ST*>(pointer);
+}
+
+// ===========================================================================
+// trackd controller API
+
+struct ControllerConnection
+{
+#if defined(VPR_OS_Windows)
+   HANDLE                        file_mapping;
+   CAVE_TRACKDCONTROLLER_HEADER* controller;
+#else
+   int                           shmid;
+   CAVE_TRACKDCONTROLLER_HEADER* controller;
+#endif
+};
+
+ControllerConnection*
+trackd_controller_attach(int shmKey)
+{
+   ControllerConnection* c = new ControllerConnection();
+
+#if defined(VPR_OS_Windows)
+   char shmfile[256];
+   sprintf(shmfile, "%d", shmKey);
+   c->file_mapping = OpenFileMapping(FILE_MAP_READ, FALSE, shmfile);
+
+   if(!c->file_mapping)
+   {
+      fprintf(stderr, "ERROR: cannot get controller shared memory\n");
+      perror("OpenFileMapping");
+      return NULL;
    }
 
+   c->controller =
+      reinterpret_cast<CAVE_TRACKDCONTROLLER_HEADER*>(
+         MapViewOfFile(c->file_mapping, FILE_MAP_READ, 0, 0, 0));
 
-int trackd_num_sensors(void *mem)
+   if(!c->controller)
    {
-   CAVE_TRACKDTRACKER_HEADER *tracker=(CAVE_TRACKDTRACKER_HEADER*)mem;
-   return tracker->numSensors;
+      fprintf(stderr, "ERROR: cannot attach controller shared memory\n");
+      perror("MapViewOfFile");
+      return NULL;
    }
+#else
+   c->shmid = shmget(shmKey, sizeof(CAVE_TRACKDCONTROLLER_HEADER), 0);
 
-
-CAVE_SENSOR_ST * trackd_sensor(void *mem,int sensorNum)
+   if(c->shmid < 0)
    {
-   CAVE_TRACKDTRACKER_HEADER *tracker=(CAVE_TRACKDTRACKER_HEADER*)mem;
-   unsigned char *pointer = (unsigned char *)mem;
-   pointer += tracker->sensorOffset + sensorNum * tracker->sensorSize;
-   return (CAVE_SENSOR_ST *) pointer;
-   }
-
-
-/*************************************************************************
- void * trackd_attach_controller_mem(int)
-   Attaches to shared memory for the buttons/joystick.  The argument
-  is the key # for the shared memory segment.  The returned value points
-  to the chunk.
-**************************************************************************/
-void * trackd_attach_controller_mem(int shmKey)
-   {
-   CAVE_TRACKDCONTROLLER_HEADER *controller;
-   int controller_shmid = shmget(shmKey,
-            sizeof(CAVE_TRACKDCONTROLLER_HEADER), 0);
-   if (controller_shmid < 0)
-      {
       fprintf(stderr,"ERROR: can't get controller shared memory\n");
       perror("shmget");
       return NULL;
-      }
-   controller = (CAVE_TRACKDCONTROLLER_HEADER *)
-            shmat(controller_shmid,(void *) 0, 0);
-   if (controller == (CAVE_TRACKDCONTROLLER_HEADER *) -1)
-      {
+   }
+
+   c->controller =
+      reinterpret_cast<CAVE_TRACKDCONTROLLER_HEADER*>(
+         shmat(controller_shmid, (void *) 0, 0));
+
+   if(c->controller == (CAVE_TRACKDCONTROLLER_HEADER *) -1)
+   {
       fprintf(stderr,"ERROR: can't attach controller shared memory\n");
       perror("shmat");
       return NULL;
-      }
-   return controller;
    }
-
-
-void trackd_release_controller_mem(void *mem)
-   {
-#ifdef __sun__
-#   if defined(_XOPEN_SOURCE) && (_XOPEN_VERSION - 0 >= 4)
-   shmdt(mem);
-#   else
-   shmdt((char*) mem);
-#   endif
-#else
-   shmdt(mem);
 #endif
-   }
 
+   return c;
+}
 
-int trackd_num_buttons(void *mem)
+void
+trackd_controller_release(ControllerConnection* c)
+{
+#if defined(VPR_OS_Windows)
+   if(c && c->controller)
    {
-   CAVE_TRACKDCONTROLLER_HEADER *controller =
-            (CAVE_TRACKDCONTROLLER_HEADER*)mem;
-   return controller->numButtons;
+      UnmapViewOfFile(c->controller);
+      CloseHandle(c->file_mapping);
    }
-
-
-int trackd_num_valuators(void *mem)
+#else
+   if(c && c->controller)
    {
-   CAVE_TRACKDCONTROLLER_HEADER *controller =
-            (CAVE_TRACKDCONTROLLER_HEADER*)mem;
-   return controller->numValuators;
+#  ifdef __sun__
+#     if defined(_XOPEN_SOURCE) && (_XOPEN_VERSION - 0 >= 4)
+      shmdt(c->controller);
+#     else
+      shmdt((char*) c->controller);
+#     endif
+#  else
+      shmdt(c->controller);
+#  endif
    }
+#endif
 
+   delete c;
+}
 
-int trackd_button(void *mem,int buttonNum)
-   {
-   CAVE_TRACKDCONTROLLER_HEADER *controller =
-            (CAVE_TRACKDCONTROLLER_HEADER*)mem;
-   unsigned char *pointer = (unsigned char *) controller;
-   int *buttons = (int *) (pointer + controller->buttonOffset);
+int
+trackd_controller_num_buttons(ControllerConnection* c)
+{
+   return c->controller->numButtons;
+}
+
+int
+trackd_controller_num_valuators(ControllerConnection* c)
+{
+   return c->controller->numValuators;
+}
+
+int
+trackd_controller_button(ControllerConnection* c, int buttonNum)
+{
+   unsigned char* pointer =
+      reinterpret_cast<unsigned char*>(c->controller)
+      + c->controller->buttonOffset;
+   int* buttons = reinterpret_cast<int*>(pointer);
+
    return buttons[buttonNum];
-   }
+}
 
+float
+trackd_controller_valuator(ControllerConnection* c, int valuatorNum)
+{
+   unsigned char* pointer =
+      reinterpret_cast<unsigned char*>(c->controller)
+      + c->controller->valuatorOffset;
+   float* valuators = reinterpret_cast<float*>(pointer);
 
-float trackd_valuator(void *mem,int valuatorNum)
-   {
-   CAVE_TRACKDCONTROLLER_HEADER *controller =
-            (CAVE_TRACKDCONTROLLER_HEADER*)mem;
-   unsigned char *pointer = (unsigned char *) controller;
-   float *valuators = (float *) (pointer + controller->valuatorOffset);
    return valuators[valuatorNum];
-   }
+}

--- a/modules/gadgeteer/drivers/Open/Trackd/trackdmem.h
+++ b/modules/gadgeteer/drivers/Open/Trackd/trackdmem.h
@@ -13,13 +13,13 @@
 #endif
 
 struct CAVE_SENSOR_ST
-   {
+{
    float       x, y, z;
    float       azim, elev, roll;
    uint32_t    timestamp[2];
    int32_t     calibrated;
    int32_t     frame;
-   };
+};
 
 struct CAVE_TRACKDTRACKER_HEADER
 {
@@ -53,7 +53,32 @@ struct CAVE_TRACKDCONTROLLER_HEADER
     either the header, sensor, or controller struct definition is expanded */
 #define CAVELIB_2_6  1
 
+struct TrackerConnection;
+struct ControllerConnection;
 
+TrackerConnection*
+trackd_tracker_attach(int shmKey);
+void
+trackd_tracker_release(TrackerConnection* t);
+int
+trackd_tracker_num_sensors(TrackerConnection* t);
+CAVE_SENSOR_ST*
+trackd_tracker_sensor(TrackerConnection* t, int sensorNum);
+
+ControllerConnection*
+trackd_controller_attach(int shmKey);
+void
+trackd_controller_release(ControllerConnection* c);
+int
+trackd_controller_num_buttons(ControllerConnection* c);
+int
+trackd_controller_num_valuators(ControllerConnection* c);
+int
+trackd_controller_button(ControllerConnection* c, int buttonNum);
+float
+trackd_controller_valuator(ControllerConnection* c, int valuatorNum);
+
+#if 0
 void * trackd_attach_tracker_mem(int shmKey);
 void trackd_release_tracker_mem(void *mem);
 int trackd_num_sensors(void *mem);
@@ -64,5 +89,6 @@ int trackd_num_buttons(void *mem);
 int trackd_num_valuators(void *mem);
 int trackd_button(void *mem,int buttonNum);
 float trackd_valuator(void *mem,int valuatorNum);
+#endif
 
 #endif

--- a/modules/gadgeteer/drivers/Open/Trackd/trackdmem.h
+++ b/modules/gadgeteer/drivers/Open/Trackd/trackdmem.h
@@ -78,17 +78,4 @@ trackd_controller_button(ControllerConnection* c, int buttonNum);
 float
 trackd_controller_valuator(ControllerConnection* c, int valuatorNum);
 
-#if 0
-void * trackd_attach_tracker_mem(int shmKey);
-void trackd_release_tracker_mem(void *mem);
-int trackd_num_sensors(void *mem);
-CAVE_SENSOR_ST * trackd_sensor(void *mem,int sensorNum);
-void * trackd_attach_controller_mem(int shmKey);
-void trackd_release_controller_mem(void *mem);
-int trackd_num_buttons(void *mem);
-int trackd_num_valuators(void *mem);
-int trackd_button(void *mem,int buttonNum);
-float trackd_valuator(void *mem,int valuatorNum);
-#endif
-
 #endif


### PR DESCRIPTION
This makes the Trackd driver available on Windows. Some amount of restructuring was required because the Win32 API requires two objects to identify a block of shared memory and the previous low-level helper (trackdmem.{h,cpp}) functions could not handle that well.

Please note: This does NOT include changes to the autotools build or Visual Studio project files. I only build with CMake these days using a variant of Ryan Pavlik's work (see https://github.com/cneumann/vrjuggler/tree/cmake-build).