### PR TITLE
Fix window leave swapgroup

### DIFF
--- a/modules/vrjuggler/vrj/Draw/OpenGL/WindowWin32.cpp
+++ b/modules/vrjuggler/vrj/Draw/OpenGL/WindowWin32.cpp
@@ -314,6 +314,27 @@ bool WindowWin32::close()
       return false;
    }
 
+   // Check on using swap group
+   jccl::ConfigElementPtr disp_sys_elt =
+      DisplayManager::instance()->getDisplaySystemElement();
+   bool use_swap_group = disp_sys_elt->getProperty<bool>("use_swap_group");
+
+   if(use_swap_group)
+   {
+      vprDEBUG_OutputGuard(vprDBG_ALL, vprDBG_CONFIG_STATUS_LVL,
+         "Attempting to leave WGL swap group.\n", "");
+
+      // Try NV swap group extension
+      if(mExtensions.hasSwapGroupNV())
+      {
+         // swap group 0 is "not a swap group", i.e. leave current group
+         mExtensions.wglJoinSwapGroupNV(mDeviceContext, 0);
+
+         // do NOT undo the swap barrier setup, there may be other windows
+         // in the swap group that still want to use the barrier
+      }
+   }
+
    // Remove window from window list
    WindowWin32::removeWindow(mWinHandle);
 

--- a/modules/vrjuggler/vrj/Draw/OpenGL/WindowWin32.cpp
+++ b/modules/vrjuggler/vrj/Draw/OpenGL/WindowWin32.cpp
@@ -254,21 +254,13 @@ bool WindowWin32::open()
 
    if(use_swap_group)
    {
-      vprDEBUG_OutputGuard(vprDBG_ALL, vprDBG_CONFIG_STATUS_LVL,
-                           "Attempting to set up WGL swap group.\n", "");
-
-      // Try NV swap group extension
+      // Use WGL_NV_swap_group extension if available
       if(mExtensions.hasSwapGroupNV())
       {
-         vprDEBUG(vprDBG_ALL, vprDBG_CONFIG_STATUS_LVL)
-            << "SwapGroupNV: " << mExtensions.hasSwapGroupNV() << std::endl
-            << vprDEBUG_FLUSH;
-         unsigned int max_groups, max_barriers;
-         mExtensions.wglQueryMaxSwapGroupsNV(mDeviceContext, &max_groups,
-                                             &max_barriers);
-         vprDEBUG(vprDBG_ALL, vprDBG_CONFIG_STATUS_LVL)
-            << "Max groups: " << max_groups << " Max Barriers:" << max_barriers
-            << std::endl << vprDEBUG_FLUSH;
+         unsigned int max_groups = 0u;
+         unsigned int max_barriers 0u;
+         mExtensions.wglQueryMaxSwapGroupsNV(
+            mDeviceContext, &max_groups, &max_barriers);
 
          // Use group 1, barrier 1 if any groups/barriers are supported
          // Note: In the future this code may need to be refactored to be
@@ -278,9 +270,9 @@ bool WindowWin32::open()
          unsigned int group_id   = (max_groups   > 0u) ? 1u : 0u;
          unsigned int barrier_id = (max_barriers > 0u) ? 1u : 0u;
          vprDEBUG(vrjDBG_DRAW_MGR, vprDBG_CONFIG_STATUS_LVL)
-            << "Setting up NV swap group and barrier group. "
-            << "Group: " << group_id
-            << ", Barrier: " << barrier_id << "\n" << vprDEBUG_FLUSH;
+            << "[WindowWin32::open] Joining WGL_NV_swap_group swap group ["
+            << group_id << "] and binding barrier group [" << barrier_id
+            << "]\n" << vprDEBUG_FLUSH;
 
          bool joinedGroup  = false;
          bool boundBarrier = false;
@@ -298,17 +290,17 @@ bool WindowWin32::open()
          }
 
          vprDEBUG(vrjDBG_DRAW_MGR, vprDBG_CONFIG_STATUS_LVL)
-            << "wglJoinSwapGroupNV: "
-            << (joinedGroup ? "succeeded" : "failed")
+            << "[WindowWin32::open] wglJoinSwapGroupNV: "
+            << (joinedGroup ? "success" : "failure")
             << " wglBindSwapBarrierNV: "
-            << (boundBarrier ? "succeeded" : "failed")
+            << (boundBarrier ? "success" : "failure")
             << "\n" << vprDEBUG_FLUSH;
       }
       else
       {
          vprDEBUG(vprDBG_ALL, vprDBG_WARNING_LVL)
-            << "Could not detect any WGL extensions that support swap groups.\n"
-            << vprDEBUG_FLUSH;
+            << "[WindowWin32::open] Swap group requested but no WGL extension "
+            << "for swap groups detected.\n" << vprDEBUG_FLUSH;
          vprDEBUG_NEXT(vprDBG_ALL, vprDBG_WARNING_LVL)
             << "Proceeding with no swap locking.\n" << vprDEBUG_FLUSH;
       }
@@ -342,19 +334,37 @@ bool WindowWin32::close()
       DisplayManager::instance()->getDisplaySystemElement();
    bool use_swap_group = disp_sys_elt->getProperty<bool>("use_swap_group");
 
-   if(use_swap_group)
+   if( use_swap_group )
    {
-      vprDEBUG_OutputGuard(vprDBG_ALL, vprDBG_CONFIG_STATUS_LVL,
-         "Attempting to leave WGL swap group.\n", "");
-
-      // Try NV swap group extension
-      if(mExtensions.hasSwapGroupNV())
+      // Use WGL_NV_swap_group extension if available
+      if( mExtensions.hasSwapGroupNV() )
       {
-         // swap group 0 is "not a swap group", i.e. leave current group
-         mExtensions.wglJoinSwapGroupNV(mDeviceContext, 0);
+         GLuint group_id = 0u;
+         GLuint barrier_id = 0u;
 
-         // do NOT undo the swap barrier setup, there may be other windows
-         // in the swap group that still want to use the barrier
+         mExtensions.wglQuerySwapGroupNV(
+            mDeviceContext, &group_id, &barrier_id);
+
+         if(group_id > 0u)
+         {
+            vprDEBUG(vrjDBG_DRAW_MGR, vprDBG_CONFIG_STATUS_LVL)
+               << "[WindowWin32::close] Leaving WGL_NV_swap_group swap "
+               << "group [" << group_id << "]\n"
+               << vprDEBUG_FLUSH;
+
+            // swap group 0 is "not a swap group", i.e. leave current group
+            mExtensions.wglJoinSwapGroupNV(mDeviceContext, 0);
+
+            // do NOT undo the swap barrier setup, there may be other
+            // windows in the swap group that still want to use the barrier
+         }
+         else
+         {
+            vprDEBUG(vrjDBG_DRAW_MGR, vprDBG_CONFIG_STATUS_LVL)
+               << "[WindowWin32::close] Not joined to any WGL_NV_swap_group "
+               << "swap group. Nothing to do.\n"
+               << vprDEBUG_FLUSH;
+         }
       }
    }
 

--- a/modules/vrjuggler/vrj/Draw/OpenGL/WindowWin32.cpp
+++ b/modules/vrjuggler/vrj/Draw/OpenGL/WindowWin32.cpp
@@ -270,16 +270,39 @@ bool WindowWin32::open()
             << "Max groups: " << max_groups << " Max Barriers:" << max_barriers
             << std::endl << vprDEBUG_FLUSH;
 
-         vprDEBUG(vprDBG_ALL, vprDBG_CONFIG_STATUS_LVL)
-            << "Setting up NV swap group and barrier group. "
-            << "Group: 1, Barrier: 1\n" << vprDEBUG_FLUSH;
-         // For now, just assume both groups are group 1
+         // Use group 1, barrier 1 if any groups/barriers are supported
          // Note: In the future this code may need to be refactored to be
          //       controlled from the vrj::opengl::Pipe class since it is
          //       really the thing that would correspond to the group and
          //       could group the correct windows to a group id.
-         mExtensions.wglJoinSwapGroupNV(mDeviceContext, 1);
-         mExtensions.wglBindSwapBarrierNV(1, 1);
+         unsigned int group_id   = (max_groups   > 0u) ? 1u : 0u;
+         unsigned int barrier_id = (max_barriers > 0u) ? 1u : 0u;
+         vprDEBUG(vrjDBG_DRAW_MGR, vprDBG_CONFIG_STATUS_LVL)
+            << "Setting up NV swap group and barrier group. "
+            << "Group: " << group_id
+            << ", Barrier: " << barrier_id << "\n" << vprDEBUG_FLUSH;
+
+         bool joinedGroup  = false;
+         bool boundBarrier = false;
+
+         if(group_id > 0u)
+         {
+            joinedGroup =
+               mExtensions.wglJoinSwapGroupNV(mDeviceContext, group_id);
+         }
+
+         if(joinedGroup && barrier_id > 0u)
+         {
+            boundBarrier =
+               mExtensions.wglBindSwapBarrierNV(group_id, barrier_id);
+         }
+
+         vprDEBUG(vrjDBG_DRAW_MGR, vprDBG_CONFIG_STATUS_LVL)
+            << "wglJoinSwapGroupNV: "
+            << (joinedGroup ? "succeeded" : "failed")
+            << " wglBindSwapBarrierNV: "
+            << (boundBarrier ? "succeeded" : "failed")
+            << "\n" << vprDEBUG_FLUSH;
       }
       else
       {

--- a/modules/vrjuggler/vrj/Draw/OpenGL/WindowWin32.cpp
+++ b/modules/vrjuggler/vrj/Draw/OpenGL/WindowWin32.cpp
@@ -257,8 +257,8 @@ bool WindowWin32::open()
       // Use WGL_NV_swap_group extension if available
       if(mExtensions.hasSwapGroupNV())
       {
-         unsigned int max_groups = 0u;
-         unsigned int max_barriers 0u;
+         unsigned int max_groups   = 0u;
+         unsigned int max_barriers = 0u;
          mExtensions.wglQueryMaxSwapGroupsNV(
             mDeviceContext, &max_groups, &max_barriers);
 
@@ -274,8 +274,8 @@ bool WindowWin32::open()
             << group_id << "] and binding barrier group [" << barrier_id
             << "]\n" << vprDEBUG_FLUSH;
 
-         bool joinedGroup  = false;
-         bool boundBarrier = false;
+         BOOL joinedGroup  = false;
+         BOOL boundBarrier = false;
 
          if(group_id > 0u)
          {
@@ -339,8 +339,8 @@ bool WindowWin32::close()
       // Use WGL_NV_swap_group extension if available
       if( mExtensions.hasSwapGroupNV() )
       {
-         GLuint group_id = 0u;
-         GLuint barrier_id = 0u;
+         unsigned int group_id = 0u;
+         unsigned int barrier_id = 0u;
 
          mExtensions.wglQuerySwapGroupNV(
             mDeviceContext, &group_id, &barrier_id);

--- a/modules/vrjuggler/vrj/Draw/OpenGL/WindowXWin.cpp
+++ b/modules/vrjuggler/vrj/Draw/OpenGL/WindowXWin.cpp
@@ -482,6 +482,26 @@ bool WindowXWin::close()
    }
    if ( mXWindow )
    {
+      // Check on using swap group
+      jccl::ConfigElementPtr disp_sys_elt =
+         DisplayManager::instance()->getDisplaySystemElement();
+      bool use_swap_group = disp_sys_elt->getProperty<bool>("use_swap_group");
+
+      if ( use_swap_group )
+      {
+         vprDEBUG_OutputGuard(vprDBG_ALL, vprDBG_CONFIG_STATUS_LVL,
+            "Attempting to leave GLX swap group.\n", "");
+
+         if(mExtensions.hasSwapGroupNV())
+         {
+            // swap group 0 is "not a swap group", i.e. leave current group
+            mExtensions.glXJoinSwapGroupNV(mXDisplay, mXWindow, 0);
+
+            // do NOT undo the swap barrier setup, there may be other windows
+            // in the swap group that still want to use the barrier
+         }
+      }
+
       ::XDestroyWindow(mXDisplay, mXWindow);
       mXWindow = 0;
    }

--- a/modules/vrjuggler/vrj/Draw/OpenGL/WindowXWin.cpp
+++ b/modules/vrjuggler/vrj/Draw/OpenGL/WindowXWin.cpp
@@ -424,38 +424,53 @@ bool WindowXWin::open()
 
    if ( use_swap_group )
    {
-      vprDEBUG_OutputGuard(vprDBG_ALL, vprDBG_CONFIG_STATUS_LVL,
-                           "Attempting to set up GLX swap group.\n", "");
-
-      // Try NV swap group extension
-      if(mExtensions.hasSwapGroupNV())
+      // Use GLX_NV_swap_group extension if available
+      if( mExtensions.hasSwapGroupNV() )
       {
-         vprDEBUG(vprDBG_ALL, vprDBG_CONFIG_STATUS_LVL)
-            << "SwapGroupNV: " << mExtensions.hasSwapGroupNV() << std::endl
-            << vprDEBUG_FLUSH;
-         GLuint max_groups, max_barriers;
-         mExtensions.glXQueryMaxSwapGroupsNV(mXDisplay, screen, &max_groups,
-                                             &max_barriers);
-         vprDEBUG(vprDBG_ALL, vprDBG_CONFIG_STATUS_LVL)
-            << "Max groups: " << max_groups << " Max Barriers:" << max_barriers
-            << std::endl << vprDEBUG_FLUSH;
+         GLuint max_groups = 0u;
+         GLuint max_barriers = 0u;
+         mExtensions.glXQueryMaxSwapGroupsNV(
+            mXDisplay, screen, &max_groups, &max_barriers);
 
-         vprDEBUG(vprDBG_ALL, vprDBG_CONFIG_STATUS_LVL)
-            << "Setting up NV swap group and barrier group. "
-            << "Group: 1, Barrier: 1\n" << vprDEBUG_FLUSH;
-         // For now, just assume both groups are group 1
+         // Use group 1, barrier 1 if any groups/barriers are supported
          // Note: In the future this code may need to be refactored to be
          //       controlled from the vrj:opengl::Pipe class since it is
          //       really the thing that would correspond to the group and
          //       could group the correct windows to a group id.
-         mExtensions.glXJoinSwapGroupNV(mXDisplay, mXWindow, 1);
-         mExtensions.glXBindSwapBarrierNV(mXDisplay, 1, 1);
+         GLuint group_id   = (max_groups   > 0u) ? 1u : 0u;
+         GLuint barrier_id = (max_barriers > 0u) ? 1u : 0u;
+         vprDEBUG(vrjDBG_DRAW_MGR, vprDBG_CONFIG_STATUS_LVL)
+            << "[WindowXWin::open] Joining GLX_NV_swap_group swap group ["
+            << group_id << "] and binding barrier group [" << barrier_id
+            << "]\n" << vprDEBUG_FLUSH;
+
+         bool joinedGroup  = false;
+         bool boundBarrier = false;
+
+         if(group_id > 0u)
+         {
+            joinedGroup = mExtensions.glXJoinSwapGroupNV(
+               mXDisplay, mXWindow, group_id);
+         }
+
+         if(joinedGroup && barrier_id > 0u)
+         {
+            boundBarrier = mExtensions.glXBindSwapBarrierNV(
+               mXDisplay, group_id, barrier_id);
+         }
+
+         vprDEBUG(vrjDBG_DRAW_MGR, vprDBG_CONFIG_STATUS_LVL)
+            << "[WindowXWin::open] glXJoinSwapGroupNV: "
+            << (joinedGroup ? "success" : "failure")
+            << " glXBindSwapBarrierNV: "
+            << (boundBarrier ? "success" : "failure")
+            << "\n" << vprDEBUG_FLUSH;
       }
       else
       {
          vprDEBUG(vprDBG_ALL, vprDBG_WARNING_LVL)
-            << "Could not detect any GLX extensions that support swap groups.\n"
-            << vprDEBUG_FLUSH;
+            << "[WindowXWin::open] Swap group requested but no GLX extension "
+            << "for swap groups detected.\n" << vprDEBUG_FLUSH;
          vprDEBUG_NEXT(vprDBG_ALL, vprDBG_WARNING_LVL)
             << "Proceeding with no swap locking.\n" << vprDEBUG_FLUSH;
       }
@@ -476,12 +491,7 @@ bool WindowXWin::close()
    {
       makeCurrent();    // Might not need this
       //glFlush();      // This is done by the changing context
-      glXMakeCurrent(mXDisplay, None, NULL);     // Release the context, and don't assign a new one
-      glXDestroyContext(mXDisplay, mGlxContext);
-      mGlxContext = NULL;
-   }
-   if ( mXWindow )
-   {
+
       // Check on using swap group
       jccl::ConfigElementPtr disp_sys_elt =
          DisplayManager::instance()->getDisplaySystemElement();
@@ -489,19 +499,43 @@ bool WindowXWin::close()
 
       if ( use_swap_group )
       {
-         vprDEBUG_OutputGuard(vprDBG_ALL, vprDBG_CONFIG_STATUS_LVL,
-            "Attempting to leave GLX swap group.\n", "");
-
-         if(mExtensions.hasSwapGroupNV())
+         if( mExtensions.hasSwapGroupNV() )
          {
-            // swap group 0 is "not a swap group", i.e. leave current group
-            mExtensions.glXJoinSwapGroupNV(mXDisplay, mXWindow, 0);
+            GLuint group_id = 0u;
+            GLuint barrier_id = 0u;
 
-            // do NOT undo the swap barrier setup, there may be other windows
-            // in the swap group that still want to use the barrier
+            mExtensions.glXQuerySwapGroupNV(
+               mXDisplay, mXWindow, &group_id, &barrier_id);
+
+            if(group_id > 0u)
+            {
+               vprDEBUG(vrjDBG_DRAW_MGR, vprDBG_CONFIG_STATUS_LVL)
+                  << "[WindowXWin::close] Leaving GLX_NV_swap_group swap "
+                  << "group [" << group_id << "]\n"
+                  << vprDEBUG_FLUSH;
+
+               // swap group 0 is "not a swap group", i.e. leave current group
+               mExtensions.glXJoinSwapGroupNV(mXDisplay, mXWindow, 0u);
+
+               // do NOT undo the swap barrier setup, there may be other
+               // windows in the swap group that still want to use the barrier
+            }
+            else
+            {
+               vprDEBUG(vrjDBG_DRAW_MGR, vprDBG_CONFIG_STATUS_LVL)
+                  << "[WindowXWin::close] Not joined to any GLX_NV_swap_group "
+                  << "swap group. Nothing to do.\n"
+                  << vprDEBUG_FLUSH;
+            }
          }
       }
 
+      glXMakeCurrent(mXDisplay, None, NULL);     // Release the context, and don't assign a new one
+      glXDestroyContext(mXDisplay, mGlxContext);
+      mGlxContext = NULL;
+   }
+   if ( mXWindow )
+   {
       ::XDestroyWindow(mXDisplay, mXWindow);
       mXWindow = 0;
    }


### PR DESCRIPTION
This short patch series makes sure that a windows that has joined a swap group leaves the group when it is closed. It is the second part mentioned in PR #73 to avoid cluster nodes getting stuck on exit.